### PR TITLE
Remove nbformat: 3 | 4 | 5  type in types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,6 @@ export type LanguageType = "python" | "r" | "julia";
 export type BaseProps = {
   ipynb: {
     cells: CellType[];
-    nbformat: 3 | 4 | 5;
     worksheets?: { cells: CellType[] }[];
   };
   syntaxTheme?: SyntaxThemeType;


### PR DESCRIPTION
Remove  nbformat: 3 | 4 | 5 because they are number typed rather than a type for ipynb.