### PR TITLE
Wip: Forward ref

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { Ref, forwardRef, memo } from "react";
 import { Cell } from "./components/Cell";
 import {
   MarkdownOptionsForMathjax,
   MarkdownForMathjax,
 } from "./components/MarkdownForMathjax";
-import {BaseProps, IpynbType} from "./types";
+import { BaseProps, IpynbType } from "./types";
 import pkg from "../package.json";
 import { defaultHtmlFilter } from "./filters";
 import { Context } from "./context";
@@ -17,35 +17,45 @@ export type Props = BaseProps & {
   markdownOptions?: MarkdownOptionsForMathjax;
 };
 
-export const IpynbRenderer: React.FC<Props> = React.memo(
-  ({
-    ipynb,
-    syntaxTheme = "xonokai",
-    language = "python",
-    bgTransparent = true,
-    markdownOptions = {},
-    htmlFilter = defaultHtmlFilter,
-    seqAsExecutionCount = false,
-  }) => {
-    const cells = ipynb.cells || ipynb.worksheets?.[0]?.cells || [];
-    return (
-      <div className="react-ipynb-renderer-mathjax react-ipynb-renderer ipynb-renderer-root container">
-        <Context.Provider
-          value={{
-            syntaxTheme,
-            language,
-            bgTransparent,
-            markdownOptions,
-            seqAsExecutionCount,
-            htmlFilter,
-            Markdown: MarkdownForMathjax,
-          }}
+export type IpynbRef = Ref<HTMLDivElement>;
+
+export const IpynbRenderer: React.FC<Props> = memo(
+  forwardRef(
+    (
+      {
+        ipynb,
+        syntaxTheme = "xonokai",
+        language = "python",
+        bgTransparent = true,
+        markdownOptions = {},
+        htmlFilter = defaultHtmlFilter,
+        seqAsExecutionCount = false,
+      }: Props,
+      ref: IpynbRef
+    ) => {
+      const cells = ipynb.cells || ipynb.worksheets?.[0]?.cells || [];
+      return (
+        <div
+          ref={ref}
+          className="react-ipynb-renderer-mathjax react-ipynb-renderer ipynb-renderer-root container"
         >
-          {cells.map((cell, i) => {
-            return <Cell key={i} cell={cell} seq={i + 1} />;
-          })}
-        </Context.Provider>
-      </div>
-    );
-  }
+          <Context.Provider
+            value={{
+              syntaxTheme,
+              language,
+              bgTransparent,
+              markdownOptions,
+              seqAsExecutionCount,
+              htmlFilter,
+              Markdown: MarkdownForMathjax,
+            }}
+          >
+            {cells.map((cell, i) => {
+              return <Cell key={i} cell={cell} seq={i + 1} />;
+            })}
+          </Context.Provider>
+        </div>
+      );
+    }
+  )
 );


### PR DESCRIPTION
Hi, @righ ! Thank you for this awesome library! 

I am working on a project that requires displaying Jupyter notebooks in a next.js website. However, I run into issues when dynamically loading the component using `next/dynamic`.

One thing is that I would like to know when the component has loaded. I know you can use [the `loading` attribute ](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#examples) but I can't modify the state of the parent component in that case.

The other reason is, that I would like to parse the HTML output from the `react-ipynb-renderer ` component and generate a table of contents by doing a `.querySelectAll('h1,h2,h3')` in that component. When running in a simple React app, that is fine since I can just use a `ref` in the parent component but when using the Lazy Load in next.js with `{ssr: false}`, this makes things complicated since I don't know when the notebook has rendered. 

Either way, I think it will be generally useful to be able to pass a ref to this notebook regardless of this particular use case. 

What do you think of this? Also, in order to merge this, apart from examples, what else do I need to add to make this change? 

Thank you! 